### PR TITLE
Added support for post requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,39 @@ This simple client permits to execute multiple request in parallel, in a non blo
 
 ## Usage
 ```php
+
+use AsyncHttpClient\Core\AsyncHttpClient;
+use AsyncHttpClient\Core\AsyncHttpClientDefault;
+use AsyncHttpClient\Helper\TimeDefault;
+use AsyncHttpClient\Logger\AsyncHttpLoggerDefault;
+use AsyncHttpClient\Service\AsyncHttpGenericService;
+
+
 $loop               = \React\EventLoop\Factory::create();
 $dnsResolverFactory = new \React\Dns\Resolver\Factory();
 $dnsResolver        = $dnsResolverFactory->createCached('8.8.8.8', $loop);
 $factory            = new \React\HttpClient\Factory();
 $client             = $factory->create($loop, $dnsResolver);
-$logger             = new AsyncHttpLoggerDefault();
+$logger             = new AsyncHttpLoggerDefault(new TimeDefault());
 
 $asyncClient = new AsyncHttpClientDefault($client, $loop, $logger);
 
-$service = new AsyncHttpGenericService('GET', 'http://www.google.it', function ($data, $request) {
+$service = new AsyncHttpGenericService('GET', 'http://www.google.it', null, function ($data, $request) {
     // Do something
 });
 
-$asyncClient->addService($service);
+$anotherService = new AsyncHttpGenericService('POST', 'http://www.another.service.com', http_build_query(['postfield1' => 'value']) , function ($data, $request) {
+    // Do something more
+});
 
-$async->send();
+$asyncClient->addService($service);
+$asyncClient->addService($anotherService);
+
+$asyncClient->send(); // code execution will block here and the HTTP calls will be dispatched in parallel
+
+// the code execution will continue only after all http calls are dispatched and returned (callback called)
+// do other stuff here
+
 ```
 ## Contributing
 1. Fork it!

--- a/src/Core/AsyncHttpClientDefault.php
+++ b/src/Core/AsyncHttpClientDefault.php
@@ -79,7 +79,10 @@ class AsyncHttpClientDefault implements AsyncHttpClient
 
     private function createRequest(AsyncHttpService $service)
     {
-        return $this->client->request($service->getMethod(), $service->getUrl());
+        $request = $this->client->request($service->getMethod(), $service->getUrl(), $service->getHeaders());
+        $request->write($service->getContent());
+        
+        return $request;
     }
 
     private function defineHandlers(Request $request, AsyncHttpService $service)

--- a/src/Service/AsyncHttpGenericService.php
+++ b/src/Service/AsyncHttpGenericService.php
@@ -83,7 +83,7 @@ class AsyncHttpGenericService implements AsyncHttpService
             ];
         }
         
-        return null;
+        return [];
     }
     
     /**

--- a/src/Service/AsyncHttpGenericService.php
+++ b/src/Service/AsyncHttpGenericService.php
@@ -22,16 +22,23 @@ class AsyncHttpGenericService implements AsyncHttpService
      * @var string
      */
     private $url;
-
+    
+    /**
+     * @var string
+     */
+    private $content;
+    
     /**
      * @var callable
      */
     private $callback;
 
-    public function __construct($method, $url, callable $callback = null)
+    
+    public function __construct($method, $url, $content, callable $callback = null)
     {
         $this->method   = $method;
         $this->url      = $url;
+        $this->content  = $content;
         $this->callback = $callback;
     }
 
@@ -50,7 +57,12 @@ class AsyncHttpGenericService implements AsyncHttpService
     {
         return $this->url;
     }
-
+    
+    public function getContent()
+    {
+        return $this->content;
+    }
+    
     /**
      * @param          $data
      * @param Response $response

--- a/src/Service/AsyncHttpGenericService.php
+++ b/src/Service/AsyncHttpGenericService.php
@@ -58,9 +58,28 @@ class AsyncHttpGenericService implements AsyncHttpService
         return $this->url;
     }
     
+    /**
+     * @return string
+     */
     public function getContent()
     {
         return $this->content;
+    }
+    
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        if ($this->getMethod() == 'POST')
+        {
+            return [
+                'Content-Length' => strlen($this->getContent()),
+                'Content-Type' => 'application/x-www-form-urlencoded'
+            ];
+        }
+        
+        return null;
     }
     
     /**

--- a/src/Service/AsyncHttpGenericService.php
+++ b/src/Service/AsyncHttpGenericService.php
@@ -63,7 +63,11 @@ class AsyncHttpGenericService implements AsyncHttpService
      */
     public function getContent()
     {
-        return $this->content;
+        if ($this->getMethod() == 'POST') {
+            return $this->content;
+        }
+        
+        return null;
     }
     
     /**

--- a/src/Service/AsyncHttpService.php
+++ b/src/Service/AsyncHttpService.php
@@ -26,6 +26,11 @@ interface AsyncHttpService
      * @return string
      */
     public function getContent();
+    
+    /**
+     * @return array
+     */
+    public function getHeaders();
 
     /**
      * @param          $data

--- a/src/Service/AsyncHttpService.php
+++ b/src/Service/AsyncHttpService.php
@@ -21,6 +21,11 @@ interface AsyncHttpService
      * @return string
      */
     public function getUrl();
+    
+    /**
+     * @return string
+     */
+    public function getContent();
 
     /**
      * @param          $data

--- a/tests/Core/AsyncHttpClientDefaultTest.php
+++ b/tests/Core/AsyncHttpClientDefaultTest.php
@@ -19,15 +19,16 @@ use React\HttpClient\Response;
 
 class AsyncHttpClientDefaultTest extends \PHPUnit_Framework_TestCase
 {
-    public function test()
+    public function testGET()
     {
-        $method = 'GET';
-        $url    = 'RandomUrl';
+        $method             = 'GET';
+        $url                = 'RandomUrl';
+        $expectedHeaders    = [];
 
-        $reactClient = $this->mockReactClient($method, $url);
+        $reactClient = $this->mockReactClient($method, $url, $expectedHeaders);
         $eventLoop   = $this->mockEventLoop();
         $logger      = $this->mockLogger();
-        $service     = $this->mockService($method, $url);
+        $service     = $this->mockService($method, $url, $expectedHeaders);
 
         $asyncClient = new AsyncHttpClientDefault($reactClient, $eventLoop, $logger);
 
@@ -41,13 +42,13 @@ class AsyncHttpClientDefaultTest extends \PHPUnit_Framework_TestCase
     /**
      * @return Mockery\MockInterface|Client
      */
-    private function mockReactClient($method, $url)
+    private function mockReactClient($method, $url, $headers)
     {
         $mock = Mockery::mock(Client::class);
 
         $request = $this->mockRequest('aa');
 
-        $mock->shouldReceive('request')->with($method, $url)->andReturn($request);
+        $mock->shouldReceive('request')->with($method, $url, $headers)->andReturn($request);
 
         return $mock;
     }
@@ -80,15 +81,17 @@ class AsyncHttpClientDefaultTest extends \PHPUnit_Framework_TestCase
     /**
      * @return Mockery\MockInterface|AsyncHttpService
      */
-    private function mockService($method, $url)
+    private function mockService($method, $url, $headers)
     {
         $mock = Mockery::mock(AsyncHttpService::class);
 
         $mock->shouldReceive('getMethod')->twice()->andReturn($method);
         $mock->shouldReceive('getUrl')->twice()->andReturn($url);
+        $mock->shouldReceive('getHeaders')->once()->andReturn($headers);
+        $mock->shouldReceive('getContent')->once();
         $mock->shouldReceive('execute')->once();
-
-
+        
+        
         return $mock;
     }
 
@@ -125,6 +128,8 @@ class AsyncHttpClientDefaultTest extends \PHPUnit_Framework_TestCase
             return true;
         }
         );
+        
+        $mock->shouldReceive('write')->once();
 
         $mock->shouldReceive('end')->once();
 

--- a/tests/Service/AsyncHttpGenericServiceTest.php
+++ b/tests/Service/AsyncHttpGenericServiceTest.php
@@ -15,7 +15,7 @@ use React\HttpClient\Response;
 
 class AsyncHttpGenericServiceTest extends MockeryTestCase
 {
-    public function test()
+    public function testPOST()
     {
         $method   = 'POST';
         $url      = 'http://www.google.it';
@@ -23,6 +23,10 @@ class AsyncHttpGenericServiceTest extends MockeryTestCase
         $called   = false;
         $data     = '{ "result": true }';
         $response = $this->mockResponse();
+        $expectedHeaders    = [
+            'Content-Length' => strlen($content),
+            'Content-Type' => 'application/x-www-form-urlencoded'
+        ];
 
         $callback = function ($d, Response $r) use (&$called, $data, $response) {
             $called = true;
@@ -39,6 +43,35 @@ class AsyncHttpGenericServiceTest extends MockeryTestCase
         PHPUnit::assertEquals($method, $service->getMethod());
         PHPUnit::assertEquals($url, $service->getUrl());
         PHPUnit::assertEquals($content, $service->getContent());
+        PHPUnit::assertEquals($expectedHeaders, $service->getHeaders());
+    }
+    
+    public function testGET()
+    {
+        $method   = 'GET';
+        $url      = 'http://www.google.it';
+        $content  = null;
+        $called   = false;
+        $data     = '{ "result": true }';
+        $response = $this->mockResponse();
+        $expectedHeaders    = null;
+    
+        $callback = function ($d, Response $r) use (&$called, $data, $response) {
+            $called = true;
+        
+            PHPUnit::assertEquals($data, $d);
+            PHPUnit::assertEquals($response, $r);
+        };
+    
+        $service = new AsyncHttpGenericService($method, $url, $content, $callback);
+    
+        $service->execute($data, $response);
+    
+        PHPUnit::assertTrue($called);
+        PHPUnit::assertEquals($method, $service->getMethod());
+        PHPUnit::assertEquals($url, $service->getUrl());
+        PHPUnit::assertEquals($content, $service->getContent());
+        PHPUnit::assertEquals($expectedHeaders, $service->getHeaders());
     }
 
     private function mockResponse()

--- a/tests/Service/AsyncHttpGenericServiceTest.php
+++ b/tests/Service/AsyncHttpGenericServiceTest.php
@@ -54,7 +54,7 @@ class AsyncHttpGenericServiceTest extends MockeryTestCase
         $called   = false;
         $data     = '{ "result": true }';
         $response = $this->mockResponse();
-        $expectedHeaders    = null;
+        $expectedHeaders    = [];
     
         $callback = function ($d, Response $r) use (&$called, $data, $response) {
             $called = true;

--- a/tests/Service/AsyncHttpGenericServiceTest.php
+++ b/tests/Service/AsyncHttpGenericServiceTest.php
@@ -17,8 +17,9 @@ class AsyncHttpGenericServiceTest extends MockeryTestCase
 {
     public function test()
     {
-        $method   = 'GET';
+        $method   = 'POST';
         $url      = 'http://www.google.it';
+        $content  = 'field1=1&field2=2';
         $called   = false;
         $data     = '{ "result": true }';
         $response = $this->mockResponse();
@@ -30,13 +31,14 @@ class AsyncHttpGenericServiceTest extends MockeryTestCase
             PHPUnit::assertEquals($response, $r);
         };
 
-        $service = new AsyncHttpGenericService($method, $url, $callback);
+        $service = new AsyncHttpGenericService($method, $url, $content, $callback);
 
         $service->execute($data, $response);
 
         PHPUnit::assertTrue($called);
         PHPUnit::assertEquals($method, $service->getMethod());
         PHPUnit::assertEquals($url, $service->getUrl());
+        PHPUnit::assertEquals($content, $service->getContent());
     }
 
     private function mockResponse()


### PR DESCRIPTION
Added support for post requests and content on the http stream. Updated tests (100% coverage preserved). Updated readme. The changes are breaking since the constructor of AsyncHttpGenericService has changed (added one parameter before the callback).